### PR TITLE
Remove temporary set columns=85

### DIFF
--- a/dotVimRc
+++ b/dotVimRc
@@ -161,12 +161,6 @@ if filereadable(expand("~/.vim/bundlesVimRc.custom"))
 endif
 NeoBundleCheck
 
-" <temporary until neobundle stops asking to hit enter for more>
-set linespace=0
-autocmd VimEnter * exec ":set columns=85"
-" </temporary until neobundle stops asking to hit enter for more>
-
-
 source ~/.vim/guiSettingsVimRc   " Must come after .bundlesVimRc
 source ~/.vim/keysVimRc
 source ~/.vim/customFunctions.vim


### PR DESCRIPTION
Remove temporary set columns=85
Summary:
Now vim start with 85 columns and it is annoying.
This fixes it. Not sure what it was in place, but it work fine for me.
